### PR TITLE
feat: added a way to confirm if a platform is supported by the plugin

### DIFF
--- a/Plugin.Maui.Biometric/Plugin.Maui.Biometric/BiometricService.cs
+++ b/Plugin.Maui.Biometric/Plugin.Maui.Biometric/BiometricService.cs
@@ -2,9 +2,13 @@
 
 internal partial class BiometricService : IBiometric
 {
+    public bool IsPlatformSupported { get; } = GetIsPlatformSupported();
+    
     public partial Task<BiometricHwStatus> GetAuthenticationStatusAsync(AuthenticatorStrength authStrength = AuthenticatorStrength.Strong);
 
     public partial Task<AuthenticationResponse> AuthenticateAsync(AuthenticationRequest request, CancellationToken token);
 
     public partial Task<List<BiometricType>> GetEnrolledBiometricTypesAsync();
+    
+    private static partial bool GetIsPlatformSupported();
 }

--- a/Plugin.Maui.Biometric/Plugin.Maui.Biometric/BiometricService.net.cs
+++ b/Plugin.Maui.Biometric/Plugin.Maui.Biometric/BiometricService.net.cs
@@ -16,5 +16,7 @@ internal partial class BiometricService : IBiometric
     {
         throw new NotImplementedException();
     }
+
+    private static partial bool GetIsPlatformSupported() => false;
 }
 #endif

--- a/Plugin.Maui.Biometric/Plugin.Maui.Biometric/IBiometric.cs
+++ b/Plugin.Maui.Biometric/Plugin.Maui.Biometric/IBiometric.cs
@@ -5,4 +5,5 @@ public interface IBiometric
     Task<BiometricHwStatus> GetAuthenticationStatusAsync(AuthenticatorStrength authStrength = AuthenticatorStrength.Strong);
     Task<AuthenticationResponse> AuthenticateAsync(AuthenticationRequest request, CancellationToken token);
     Task<List<BiometricType>> GetEnrolledBiometricTypesAsync();
+    bool IsPlatformSupported { get; }
 }

--- a/Plugin.Maui.Biometric/Plugin.Maui.Biometric/Platforms/Android/BiometricService.android.cs
+++ b/Plugin.Maui.Biometric/Plugin.Maui.Biometric/Platforms/Android/BiometricService.android.cs
@@ -125,4 +125,6 @@ internal partial class BiometricService
         }
         return Task.FromResult(availableOptions);
     }
+    
+    private static partial bool GetIsPlatformSupported() => true;
 }

--- a/Plugin.Maui.Biometric/Plugin.Maui.Biometric/Platforms/iOS/BiometricService.ios.cs
+++ b/Plugin.Maui.Biometric/Plugin.Maui.Biometric/Platforms/iOS/BiometricService.ios.cs
@@ -64,4 +64,6 @@ internal partial class BiometricService
         }
         return Task.FromResult(availableOptions);
     }
+    
+    private static partial bool GetIsPlatformSupported() => true;
 }


### PR DESCRIPTION
For net8 without platform target GetEnrolledBiometricTypesAsync should return BiometricType.None. This makes it possible to check on all platforms if biometric is support without an exception.