### PR TITLE
[iOS] Fixed false "Not Enrolled" state

### DIFF
--- a/Plugin.Maui.Biometric/Plugin.Maui.Biometric/Platforms/iOS/BiometricService.ios.cs
+++ b/Plugin.Maui.Biometric/Plugin.Maui.Biometric/Platforms/iOS/BiometricService.ios.cs
@@ -12,7 +12,7 @@ internal partial class BiometricService
         {
             if (localAuthContext.CanEvaluatePolicy(LAPolicy.DeviceOwnerAuthenticationWithBiometrics, out var _))
             {
-                if (localAuthContext.BiometryType == LABiometryType.FaceId)
+                if (localAuthContext.BiometryType != LABiometryType.None)
                 {
                     return Task.FromResult(BiometricHwStatus.Success);
                 }


### PR DESCRIPTION
The Library should check if there is _any_ type of biometric method in an iOS device instead of just FaceID. This is because there're devices like the iPhone 8 that have the supported iOS version (iOS 16 in this case), with no FaceID support, but with TouchID (i.e. Fingerprint reader)