### PR TITLE
fix: hide iOS biometric popup's "Enter Password" button if AllowPasswordAuth is false

### DIFF
--- a/Plugin.Maui.Biometric/Plugin.Maui.Biometric/Platforms/iOS/BiometricService.ios.cs
+++ b/Plugin.Maui.Biometric/Plugin.Maui.Biometric/Platforms/iOS/BiometricService.ios.cs
@@ -30,6 +30,10 @@ internal partial class BiometricService
     {
         var response = new AuthenticationResponse();
         var context = new LAContext();
+        if (request.AllowPasswordAuth is false)
+        {
+            context.LocalizedFallbackTitle = string.Empty;
+        }
         LAPolicy policy = request.AllowPasswordAuth ? LAPolicy.DeviceOwnerAuthentication : LAPolicy.DeviceOwnerAuthenticationWithBiometrics;
         if (context.CanEvaluatePolicy(policy, out NSError _))
         {


### PR DESCRIPTION
The fix for the issue #19  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced biometric authentication options with the ability to disable password authentication.
	- Improved user experience by customizing fallback titles based on authentication settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->